### PR TITLE
fix(doc) : Added Missing Syntax

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -452,7 +452,7 @@ gulp.task('build:doc', (cb) => {
       tsconfig: 'src/tsconfig.lib.json',
       hideGenerator:true,
       disableCoverage: true,
-      output: <%= skipDemo ? "`${config.outputDir}/doc/`": "`{config.outputDemoDir}/doc/`"%>
+      output: <%= skipDemo ? "`${config.outputDir}/doc/`": "`${config.outputDemoDir}/doc/`"%>
     })
   ], cb);
 });


### PR DESCRIPTION
Gulp Task `build:doc` missing syntax $ to `output: `${config.outputDemoDir}doc/` output directory. Breaks otherwise