### PR TITLE
feat(testing): add support for `jest` testing platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ These are the main features of the generator:
 * **Integrated demo app** built with [angular-cli](https://cli.angular.io) and [ng-bootstrap](https://ng-bootstrap.github.io) 
 * **Project Documentation** built with [compodoc](https://compodoc.github.io/website/) and published along with demo app :books:
 * **Continuous Integration** with [Travis CI](https://travis-ci.org)
-* **Testing Environment** with [Karma](https://karma-runner.github.io/) and [Webpack](https://webpack.github.io/)
+* **Testing Environment** with [Karma](https://karma-runner.github.io/) and [Webpack](https://webpack.github.io/) or [Jest](http://facebook.github.io/jest/)
 * **Code Coverage** with [Coveralls.io](https://coveralls.io/)
 * **Real-time Monitoring** and **Automatic Updates** of npm dependencies with [Greenkeeper](https://greenkeeper.io) :palm_tree:
 * **Enforcing of Angular Git Commit Message Guideline** with [Commitplease](https://github.com/jzaefferer/commitplease) :speech_balloon:
@@ -221,7 +221,7 @@ File / Folder       | Purpose
 `src/tsconfig.lib.json` | The typescript configuration file used to compile your library in an AoT compatible way, either as ESM/ES2015 module (when targeting Angular v4.x.x) or as ESM/ES5 module (when targeting Angular v2.x.x)
 `src/tsconfig.spec.json` | The typescript configuration file used for tests
 `src/`              | This folder will contain all the files of your library
-`config/`           | This folder contains the configuration files for tools used to test your lib (`Webpack` & `Karma`)
+`config/`           | This folder contains the configuration files for tools used to test your lib (`Webpack` & `Karma` or `Jest`)
 `demo/`             | This folder contains an integrated demo application, to showcase your library. The demo app is built with [angular-cli](https://github.com/angular/angular-cli), so everything you know about the CLI is applicable inside this folder.
 `dist/` (generated) | This generated folder contains everything that will be published as part of your package to [npm registry](https://npmjs.org).  It contains only necessary files and is built via `gulp build`command
 

--- a/app/files.js
+++ b/app/files.js
@@ -79,9 +79,11 @@ module.exports = [
   {name: 'demo/src/favicon.ico', path: 'demo/src/favicon.ico', isTpl: false},
   {name: 'demo/src/favicon.ico', path: 'demo/src/favicon.ico', isTpl: false},
   {name: 'demo/src/hmr.ts', path: 'demo/src/hmr.ts', isTpl: false},
+  {name: 'demo/src/jestGlobalMocks.ts', path: 'demo/src/jestGlobalMocks.ts', isTpl: false},
   {name: 'demo/src/main.server.ts', path: 'demo/src/main.server.ts', isTpl: false},
   {name: 'demo/src/main.ts', path: 'demo/src/main.ts', isTpl: false},
   {name: 'demo/src/polyfills.ts', path: 'demo/src/polyfills.ts', isTpl: false},
+  {name: 'demo/src/setupJest.ts', path: 'demo/src/setupJest.ts', isTpl: false},
   {name: 'demo/src/styles.scss', path: 'demo/src/styles.scss', isTpl: false},
   {name: 'demo/src/test.ts', path: 'demo/src/test.ts', isTpl: false},
   {name: 'demo/src/_tsconfig.app.json', path: 'demo/src/tsconfig.app.json', isTpl: true},
@@ -118,5 +120,7 @@ module.exports = [
   {name: 'config/_webpack.test.js', path: 'config/webpack.test.js', isTpl: true},
   {name: 'config/helpers.js', path: 'config/helpers.js', isTpl: false},
   {name: 'config/karma-test-shim.js', path: 'config/karma-test-shim.js', isTpl: false},
-  {name: 'config/_karma.conf.js', path: 'config/karma.conf.js', isTpl: true}
+  {name: 'config/jestGlobalMocks.ts', path: 'config/jestGlobalMocks.ts', isTpl: false},
+  {name: 'config/_karma.conf.js', path: 'config/karma.conf.js', isTpl: true},
+  {name: 'config/setupJest.ts', path: 'config/setupJest.ts', isTpl: false}
 ];

--- a/app/index.js
+++ b/app/index.js
@@ -326,6 +326,10 @@ module.exports = class extends Generator {
         this.exclusions.push('demo/src/main.server.ts');
         this.exclusions.push('demo/src/main.ts');
         this.exclusions.push('demo/src/polyfills.ts');
+        if(this.testingFramework !== 'jest'){
+          this.exclusions.push('demo/src/jestGlobalMocks.ts');
+          this.exclusions.push('demo/src/setupJest.ts');
+        }
         this.exclusions.push('demo/src/styles.scss');
         this.exclusions.push('demo/src/test.ts');
         this.exclusions.push('demo/src/tsconfig.app.json');
@@ -351,6 +355,17 @@ module.exports = class extends Generator {
       if (!this.useCompodoc) {
         this.exclusions.push('demo/proxy.conf.json');
       }
+
+      if(this.testingFramework === 'karma'){
+        this.exclusions.push('demo/src/jestGlobalMocks.ts');
+        this.exclusions.push('demo/src/setupJest.ts');
+        this.exclusions.push('config/jestGlobalMocks.ts');
+        this.exclusions.push('config/setupJest.ts');
+      } else if(this.testingFramework === 'jest'){
+        this.exclusions.push('config/karma.conf.js');
+        this.exclusions.push('config/webpack.test.js');
+        this.exclusions.push('config/karma-test-shim.js');
+      }
     };
 
     this.authorName = this.config.get('authorName');
@@ -362,6 +377,7 @@ module.exports = class extends Generator {
     this.projectDescription = this.config.get('projectDescription');
     this.projectKeywords = this.config.get('projectKeywords');
     this.ngPrefix = this.config.get('ngPrefix') || 'my-lib';
+    this.testingFramework = this.config.get('testingFramework') || 'karma';
     this.ngVersion = this.config.get('ngVersion');
     this.ngModules = this.config.get('ngModules');
     this.otherDependencies = this.config.get('otherDependencies') || [];
@@ -395,6 +411,7 @@ module.exports = class extends Generator {
         this.ngModules = props.ngModules;
         this.otherDependencies = props.otherDependencies ? props.otherDependencies.split(',') : [];
         this.ngPrefix = props.ngPrefix;
+        this.testingFramework = props.testingFramework;
         this.useGreenkeeper = props.useGreenkeeper;
         this.useCompodoc = props.useCompodoc;
         this.enforceNgGitCommitMsg = props.enforceNgGitCommitMsg;
@@ -422,6 +439,7 @@ module.exports = class extends Generator {
         this.config.set('otherDependencies', this.otherDependencies);
         this.config.set('dependenciesRange', this.dependenciesRange);
         this.config.set('ngPrefix', this.ngPrefix);
+        this.config.set('testingFramework', this.testingFramework);
         this.config.set('useGreenkeeper', this.useGreenkeeper);
         this.config.set('useCompodoc', this.useCompodoc);
         this.config.set('enforceNgGitCommitMsg', this.enforceNgGitCommitMsg);

--- a/app/prompts.js
+++ b/app/prompts.js
@@ -25,58 +25,58 @@ module.exports = info => {
       type: 'input',
       name: 'authorName',
       validate: validators.validateAuthorName,
-      message: '(1/15) What is your name?',
+      message: '(1/16) What is your name?',
       default: info.git.name
     },
     {
       type: 'input',
       name: 'authorEmail',
       validate: validators.validateAuthorEmail,
-      message: '(2/15) What is your email address?',
+      message: '(2/16) What is your email address?',
       default: info.git.email
     },
     {
       type: 'input',
       name: 'githubUsername',
       validate: validators.validateGithubUsername,
-      message: '(3/15) What is your Github username?'
+      message: '(3/16) What is your Github username?'
     },
     {
       type: 'input',
       name: 'githubRepoName',
       validate: validators.validateGithubRepoName,
-      message: '(4/15) What is your Github repository name?'
+      message: '(4/16) What is your Github repository name?'
     },
     {
       type: 'input',
       name: 'projectName',
       validate: validators.validateProjectName,
-      message: '(5/15) What is the name of your project?',
+      message: '(5/16) What is the name of your project?',
       default: 'my-ngx-library'
     },
     {
       type: 'input',
       name: 'projectVersion',
       validate: validators.validateProjectVersion,
-      message: '(6/15) What is the version of your project?',
+      message: '(6/16) What is the version of your project?',
       default: '0.0.1'
     },
     {
       type: 'input',
       name: 'projectDescription',
-      message: '(7/15) What is the description of your project?',
+      message: '(7/16) What is the description of your project?',
       default: 'Angular library built with ❤ using ngx-library yeoman generator.'
     },
     {
       type: 'input',
       name: 'projectKeywords',
-      message: '(8/15) What keywords best describe your project (comma-separated)?',
+      message: '(8/16) What keywords best describe your project (comma-separated)?',
       default: 'ng,angular,library'
     },
     {
       type: 'list',
       name: 'ngVersion',
-      message: '(9/15) What minimal version of Angular do you want to base your library upon?',
+      message: '(9/16) What minimal version of Angular do you want to base your library upon?',
       choices: [
         {name: '2.X.X', value: '2.0.0'},
         {name: '4.X.X', value: '4.0.0'},
@@ -87,38 +87,47 @@ module.exports = info => {
       type: 'checkbox',
       name: 'ngModules',
       validate: validators.validateNgModules,
-      message: '(10/15) What Angular modules will your library use?',
+      message: '(10/16) What Angular modules will your library use?',
       choices: NG_MODULES
     },
     {
       type: 'input',
       name: 'otherDependencies',
-      message: '(11/15) What other NPM packages your project depends upon? (comma-separated)?',
+      message: '(11/16) What other NPM packages your project depends upon? (comma-separated)?',
       default: ''
     },
     {
       type: 'input',
       name: 'ngPrefix',
       validate: validators.validateNgPrefix,
-      message: '(12/15) What prefix would you like to use to name your components, directives,...?',
+      message: '(12/16) What prefix would you like to use to name your components, directives,...?',
       default: 'my-lib'
+    },
+    {
+      type: 'list',
+      name: 'testingFramework',
+      message: '(13/16) What testing framework do you want to use?',
+      choices: [
+        {name: 'Karma', value: 'karma'},
+        {name: 'Jest', value: 'jest'}],
+      default: 0
     },
     {
       type: 'confirm',
       name: 'useGreenkeeper',
-      message: '(13/15) Do You want to use Greenkeepeer (to automatically keep your dependencies up-to-date)?',
+      message: '(14/16) Do You want to use Greenkeepeer (to automatically keep your dependencies up-to-date)?',
       default: false
     },
     {
       type: 'confirm',
       name: 'useCompodoc',
-      message: '(14/15) Do You want to use Compodoc (to generate your Angular project documentation)?',
+      message: '(15/16) Do You want to use Compodoc (to generate your Angular project documentation)?',
       default: false
     },
     {
       type: 'confirm',
       name: 'enforceNgGitCommitMsg',
-      message: '(15/15) Do You want to enforce Angular Git Commit Messages Guideline (to autogenerate CHANGELOG.md file)?',
+      message: '(16/16) Do You want to enforce Angular Git Commit Messages Guideline (to autogenerate CHANGELOG.md file)?',
       default: true
     }
   ];

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -45,7 +45,8 @@
     "webpack-dev-middleware": "1.12.0",
     "webpack-dev-server": "2.9.2",
     "karma-webpack": "2.0.5",<% } else if(testingFramework === 'jest') {%>
-    "@types/jest": "21.1.9",
+    <% if(ngVersionMin == 2) {%>"@types/jest": "16.0.7",<%} 
+    else {%>"@types/jest": "21.1.9",<% } %>
     "jest": "22.0.4",
     "jest-preset-angular": "5.0.0",<% } %>
     "@types/node": "8.0.44",

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -29,8 +29,25 @@
     <%- ngDependencies.join(',\n    ') %>
    },
   "devDependencies": {<% for (dep of ngDevDependencies) { %>
-    <%- dep %>,<% } %>
+    <%- dep %>,<% } %><% if(testingFramework === 'karma'){%>
     "@types/jasmine": "2.5.41",
+    "istanbul-instrumenter-loader": "3.0.0",
+    "jasmine-core": "2.8.0",
+    "karma": "1.7.0",
+    "karma-chrome-launcher": "2.2.0",
+    "karma-coverage": "1.1.1",
+    "karma-jasmine": "1.1.0",
+    "karma-mocha-reporter": "2.2.5",
+    "karma-jasmine-html-reporter": "0.2.2",
+    "karma-remap-coverage": "0.1.4",
+    "karma-sourcemap-loader": "0.3.7",
+    "webpack": "3.8.1",
+    "webpack-dev-middleware": "1.12.0",
+    "webpack-dev-server": "2.9.2",
+    "karma-webpack": "2.0.5",<% } else if(testingFramework === 'jest') {%>
+    "@types/jest": "21.1.9",
+    "jest": "22.0.4",
+    "jest-preset-angular": "5.0.0",<% } %>
     "@types/node": "8.0.44",
     "angular-cli-ghpages": "0.5.1",
     "angular2-template-loader": "0.6.2",<% if(useCompodoc){%>
@@ -49,18 +66,7 @@
     "gulp-inline-ng2-template": "4.0.0",
     "gulp-hub": "0.8.0",
     "gulp-util": "3.0.8",
-    "html-loader": "0.5.1",
-    "istanbul-instrumenter-loader": "3.0.0",
-    "jasmine-core": "2.8.0",
-    "karma": "1.7.0",
-    "karma-chrome-launcher": "2.2.0",
-    "karma-coverage": "1.1.1",
-    "karma-jasmine": "1.1.0",
-    "karma-mocha-reporter": "2.2.5",
-    "karma-jasmine-html-reporter": "0.2.2",
-    "karma-remap-coverage": "0.1.4",
-    "karma-sourcemap-loader": "0.3.7",
-    "karma-webpack": "2.0.5",
+    "html-loader": "0.5.1",    
     "pump": "1.0.2",
     "rollup": "0.50.0",
     "rollup-plugin-uglify": "2.0.1",
@@ -79,14 +85,18 @@
     "raw-loader": "0.5.1",
     "source-map-loader": "0.2.2",<% if(!skipTravis) {%>
     "travis-status": "2.0.0",<% } %>
-    "webpack": "3.8.1",
-    "webpack-dev-middleware": "1.12.0",
-    "webpack-dev-server": "2.9.2",
     "yargs": "10.0.3"
   },
   "engines": {
     "node": ">=6.0.0"
-  }<% if(useGreenkeeper){%>,
+  }<% if(testingFramework === 'jest'){%>,
+  "jest": {
+    "preset": "jest-preset-angular",
+    "roots": [ "<rootDir>/src/" ],
+    "coverageReporters": [ "lcov", "text" ],
+    "coveragePathIgnorePatterns": [ "/node_modules/", "/config", "/dist/"],
+    "setupTestFrameworkScriptFile": "<rootDir>/config/setupJest.ts"
+  }<% } %><% if(useGreenkeeper){%>,
   "greenkeeper": {
     "ignore": [
       <%- greenkeeperExclusions.join(',\n      ') %>

--- a/app/templates/config/jestGlobalMocks.ts
+++ b/app/templates/config/jestGlobalMocks.ts
@@ -1,0 +1,37 @@
+global['CSS'] = null;
+
+const mock = () => {
+  let storage = {};
+  return {
+    getItem: key => key in storage ? storage[key] : null,
+    setItem: (key, value) => storage[key] = value || '',
+    removeItem: key => delete storage[key],
+    clear: () => storage = {},
+  };
+};
+
+Object.defineProperty(window, 'localStorage', {value: mock()});
+Object.defineProperty(window, 'sessionStorage', {value: mock()});
+Object.defineProperty(document, 'doctype', {
+  value: '<!DOCTYPE html>'
+});
+Object.defineProperty(window, 'getComputedStyle', {
+  value: () => {
+    return {
+      display: 'none',
+      appearance: ['-webkit-appearance']
+    };
+  }
+});
+/**
+ * ISSUE: https://github.com/angular/material2/issues/7101
+ * Workaround for JSDOM missing transform property
+ */
+Object.defineProperty(document.body.style, 'transform', {
+  value: () => {
+    return {
+      enumerable: true,
+      configurable: true,
+    };
+  },
+});

--- a/app/templates/config/setupJest.ts
+++ b/app/templates/config/setupJest.ts
@@ -1,0 +1,2 @@
+import 'jest-preset-angular';
+import './jestGlobalMocks';

--- a/app/templates/demo/_package.json
+++ b/app/templates/demo/_package.json
@@ -7,7 +7,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "test": "ng test",
+    "test": "<%= testingFramework === 'jest' ? 'jest' : 'ng test' %>",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "postinstall": "npm link <%= projectName %>"
@@ -37,10 +37,10 @@
     "@angular/compiler-cli": "^5.0.0",
     "@angular/language-service": "^5.0.0",
     "@angularclass/hmr": "~2.1.3",
+    "@types/node": "~6.0.60",
+    "codelyzer": "^4.0.1",<% if(testingFramework === 'karma'){%>
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
-    "@types/node": "~6.0.60",
-    "codelyzer": "^4.0.1",
     "jasmine-core": "~2.6.2",
     "jasmine-spec-reporter": "~4.1.0",
     "karma": "~1.7.0",
@@ -48,7 +48,10 @@
     "karma-cli": "~1.0.1",
     "karma-coverage-istanbul-reporter": "^1.2.1",
     "karma-jasmine": "~1.1.0",
-    "karma-jasmine-html-reporter": "^0.2.2",
+    "karma-jasmine-html-reporter": "^0.2.2",<% } else if(testingFramework === 'jest') {%>
+    "@types/jest": "21.1.9",
+    "jest": "22.0.4",
+    "jest-preset-angular": "5.0.0",<% } %>
     "protractor": "~5.1.2",
     "ts-node": "~3.2.0",
     "tslint": "~5.7.0",
@@ -59,5 +62,10 @@
     "express": "^4.16.2",
     "@nguniversal/express-engine": "^5.0.0-beta.5",
     "@nguniversal/module-map-ngfactory-loader": "^5.0.0-beta.5"
-  }
+  }<% if(testingFramework === 'jest'){%>,
+    "jest": {
+      "preset": "jest-preset-angular",
+      "coverageReporters": [ "lcov", "text" ],
+      "setupTestFrameworkScriptFile": "<rootDir>/src/setupJest.ts"
+    }<% } %>
 }

--- a/app/templates/demo/src/app/shared/header/_header.component.spec.ts
+++ b/app/templates/demo/src/app/shared/header/_header.component.spec.ts
@@ -48,16 +48,16 @@ describe('HeaderComponent', () => {
   });
 
   it('can get RouterLinks from template', () => {
-    expect(links.length).toBe(2, 'should have 2 links');
-    expect(links[0].linkParams).toBe('/home', '1st link should go to Home');
-    expect(links[1].linkParams).toBe('/getting-started', '2nd link should go to GettingStarted');
+    expect(links.length).toBe(2<%- testingFramework === 'jest' ? '); // should have 2 links' : ', "should have 2 links");' %>
+    expect(links[0].linkParams).toBe('/home'<%- testingFramework === 'jest' ? '); // 1st link should go to Home' : ', "1st link should go to Home");' %>
+    expect(links[1].linkParams).toBe('/getting-started'<%- testingFramework === 'jest' ? '); // 2nd link should go to GettingStarted' : ', "2nd link should go to GettingStarted");' %>
   });
 
   it('can click Home link in template', () => {
     const homeLinkDe = linkDes[0];
     const homeLink = links[0];
 
-    expect(homeLink.navigatedTo).toBeNull('link should not have navigated yet');
+    expect(homeLink.navigatedTo).toBeNull(<%- testingFramework === 'jest' ? '); // link should not have navigated yet' : '"link should not have navigated yet");' %>
 
     homeLinkDe.triggerEventHandler('click', null);
     fixture.detectChanges();
@@ -69,7 +69,7 @@ describe('HeaderComponent', () => {
     const gettingStartedLinkDe = linkDes[1];
     const gettingStartedLink = links[1];
 
-    expect(gettingStartedLink.navigatedTo).toBeNull('link should not have navigated yet');
+    expect(gettingStartedLink.navigatedTo).toBeNull(<%- testingFramework === 'jest' ? '); // link should not have navigated yet' : '"link should not have navigated yet");' %>
 
     gettingStartedLinkDe.triggerEventHandler('click', null);
     fixture.detectChanges();

--- a/app/templates/demo/src/jestGlobalMocks.ts
+++ b/app/templates/demo/src/jestGlobalMocks.ts
@@ -1,0 +1,37 @@
+global['CSS'] = null;
+
+const mock = () => {
+  let storage = {};
+  return {
+    getItem: key => key in storage ? storage[key] : null,
+    setItem: (key, value) => storage[key] = value || '',
+    removeItem: key => delete storage[key],
+    clear: () => storage = {},
+  };
+};
+
+Object.defineProperty(window, 'localStorage', {value: mock()});
+Object.defineProperty(window, 'sessionStorage', {value: mock()});
+Object.defineProperty(document, 'doctype', {
+  value: '<!DOCTYPE html>'
+});
+Object.defineProperty(window, 'getComputedStyle', {
+  value: () => {
+    return {
+      display: 'none',
+      appearance: ['-webkit-appearance']
+    };
+  }
+});
+/**
+ * ISSUE: https://github.com/angular/material2/issues/7101
+ * Workaround for JSDOM missing transform property
+ */
+Object.defineProperty(document.body.style, 'transform', {
+  value: () => {
+    return {
+      enumerable: true,
+      configurable: true,
+    };
+  },
+});

--- a/app/templates/demo/src/setupJest.ts
+++ b/app/templates/demo/src/setupJest.ts
@@ -1,0 +1,2 @@
+import 'jest-preset-angular';
+import './jestGlobalMocks';

--- a/app/templates/src/module/component/_lib.component.spec.ts
+++ b/app/templates/src/module/component/_lib.component.spec.ts
@@ -27,6 +27,6 @@ describe('LibComponent', function () {
   it('should have expected <p> text', () => {
     fixture.detectChanges();
     const p = de.nativeElement;
-    expect(p.innerText).toEqual('<%= projectDescription %>');
+    expect(p.textContent).toEqual('<%= projectDescription %>');
   });
 });

--- a/integrations/.yo-rc.ng2.json
+++ b/integrations/.yo-rc.ng2.json
@@ -7,15 +7,22 @@
     "projectVersion": "0.0.1",
     "projectDescription": "Angular library built with ❤ using ngx-library yeoman generator.",
     "projectKeywords": [],
-    "ngPrefix": "my-lib",
     "moduleName": "my-ng-module",
     "ngVersion": "2.0.0",
     "ngModules": [
       "core",
       "common"
     ],
-    "useGreenkeeper": true,
-    "useCompodoc": true
+    "otherDependencies": [],
+    "dependenciesRange": "^",
+    "ngPrefix": "my-lib",
+    "testingFramework": "karma",
+    "useGreenkeeper": false,
+    "useCompodoc": false,
+    "enforceNgGitCommitMsg": true,
+    "exclusions": [
+      "demo/proxy.conf.json"
+    ]
   }
 }
 

--- a/integrations/.yo-rc.ng4.json
+++ b/integrations/.yo-rc.ng4.json
@@ -7,15 +7,22 @@
     "projectVersion": "0.0.1",
     "projectDescription": "Angular library built with ❤ using ngx-library yeoman generator.",
     "projectKeywords": [],
-    "ngPrefix": "my-lib",
     "moduleName": "my-ng-module",
     "ngVersion": "4.0.0",
     "ngModules": [
       "core",
       "common"
     ],
-    "useGreenkeeper": true,
-    "useCompodoc": true
+    "otherDependencies": [],
+    "dependenciesRange": "^",
+    "ngPrefix": "my-lib",
+    "testingFramework": "karma",
+    "useGreenkeeper": false,
+    "useCompodoc": false,
+    "enforceNgGitCommitMsg": true,
+    "exclusions": [
+      "demo/proxy.conf.json"
+    ]
   }
 }
 

--- a/integrations/.yo-rc.ng5.json
+++ b/integrations/.yo-rc.ng5.json
@@ -7,15 +7,22 @@
     "projectVersion": "0.0.1",
     "projectDescription": "Angular library built with ❤ using ngx-library yeoman generator.",
     "projectKeywords": [],
-    "ngPrefix": "my-lib",
     "moduleName": "my-ng-module",
     "ngVersion": "5.0.0",
     "ngModules": [
       "core",
       "common"
     ],
-    "useGreenkeeper": true,
-    "useCompodoc": true
+    "otherDependencies": [],
+    "dependenciesRange": "^",
+    "ngPrefix": "my-lib",
+    "testingFramework": "karma",
+    "useGreenkeeper": false,
+    "useCompodoc": false,
+    "enforceNgGitCommitMsg": true,
+    "exclusions": [
+      "demo/proxy.conf.json"
+    ]
   }
 }
 

--- a/tests/test-app.js
+++ b/tests/test-app.js
@@ -17,6 +17,7 @@ const createNgLibraryApp = (options, prompts) => {
       projectDescription: 'Angular library for ...',
       projectkeywords: 'ng, angular,library',
       ngPrefix: 'my-lib',
+      testingFramework: 'karma',
       ngVersion: '2.0.0',
       ngModules: ['core', 'common'],
       useGreenkeeper: true,
@@ -169,6 +170,7 @@ describe('ngx-library:app', () => {
           projectDescription: 'Angular library for ...',
           projectkeywords: 'ng, angular,library',
           ngPrefix: 'my-lib',
+          testingFramework: 'karma',
           ngVersion: '2.0.0',
           ngModules: ['core', 'common', 'animations'],
           useGreenkeeper: true,
@@ -212,6 +214,7 @@ describe('ngx-library:app', () => {
           projectDescription: 'Angular library for ...',
           projectkeywords: 'ng, angular,library',
           ngPrefix: 'my-lib',
+          testingFramework: 'karma',
           ngVersion: '4.0.0',
           ngModules: ['core', 'common', 'animations'],
           useGreenkeeper: true,
@@ -255,6 +258,7 @@ describe('ngx-library:app', () => {
           projectDescription: 'Angular library for ...',
           projectkeywords: 'ng, angular,library',
           ngPrefix: 'my-lib',
+          testingFramework: 'karma',
           ngVersion: '5.0.0',
           ngModules: ['core', 'common', 'animations'],
           useGreenkeeper: true,
@@ -334,6 +338,7 @@ describe('ngx-library:app', () => {
           projectDescription: 'Angular library for ...',
           projectkeywords: 'ng, angular,library',
           ngPrefix: 'my-lib',
+          testingFramework: 'karma',
           ngVersion: '2.0.0',
           ngModules: ['core', 'common'],
           useGreenkeeper: true,
@@ -364,6 +369,7 @@ describe('ngx-library:app', () => {
           projectDescription: 'Angular library for ...',
           projectkeywords: 'ng, angular,library',
           ngPrefix: 'my-lib',
+          testingFramework: 'karma',
           ngVersion: '2.0.0',
           ngModules: ['core', 'common'],
           useGreenkeeper: false,
@@ -396,6 +402,7 @@ describe('ngx-library:app', () => {
           projectDescription: 'Angular library for ...',
           projectkeywords: 'ng, angular,library',
           ngPrefix: 'my-lib',
+          testingFramework: 'karma',
           ngVersion: '2.0.0',
           ngModules: ['core', 'common'],
           useGreenkeeper: false,
@@ -425,6 +432,7 @@ describe('ngx-library:app', () => {
           projectDescription: 'Angular library for ...',
           projectkeywords: 'ng, angular,library',
           ngPrefix: 'my-lib',
+          testingFramework: 'karma',
           ngVersion: '2.0.0',
           ngModules: ['core', 'common'],
           useGreenkeeper: false,
@@ -457,6 +465,7 @@ describe('ngx-library:app', () => {
           projectDescription: 'Angular library for ...',
           projectkeywords: 'ng, angular,library',
           ngPrefix: 'my-lib',
+          testingFramework: 'karma',
           ngVersion: '2.0.0',
           ngModules: ['core', 'common'],
           useGreenkeeper: false,
@@ -485,6 +494,7 @@ describe('ngx-library:app', () => {
           projectDescription: 'Angular library for ...',
           projectkeywords: 'ng, angular,library',
           ngPrefix: 'my-lib',
+          testingFramework: 'karma',
           ngVersion: '2.0.0',
           ngModules: ['core', 'common'],
           useGreenkeeper: false,
@@ -494,6 +504,82 @@ describe('ngx-library:app', () => {
       return ngLibraryApp.then(() => {
         assert.equal(ngLibraryApp.generator.enforceNgGitCommitMsg, false);
         assert.noFileContent('package.json', '    "commitplease":');
+      });
+    });
+  });
+
+  describe('check testingFramework', () => {
+    it('should add jest-related code if "testingFramework" is set to "jest" ', () => {
+      let ngLibraryApp = createNgLibraryApp(
+        {
+          skipInstall: true,
+          skipChecks: true
+        },
+        {
+          authorName: 'Awesome Developer',
+          authorEmail: 'awesome.developer@github.com',
+          githubUsername: 'awesomedeveloper',
+          githubRepoName: 'my-ngx-library',
+          projectName: 'my-ngx-library',
+          projectVersion: '1.0.0',
+          projectDescription: 'Angular library for ...',
+          projectkeywords: 'ng, angular,library',
+          ngPrefix: 'my-lib',
+          testingFramework: 'jest',
+          ngVersion: '2.0.0',
+          ngModules: ['core', 'common'],
+          useGreenkeeper: false,
+          useCompodoc: false,
+          enforceNgGitCommitMsg: false
+        });
+      return ngLibraryApp.then(() => {
+        assert.fileContent('package.json', '    "jest":');
+        assert.file([
+          'config/jestGlobalMocks.ts',
+          'config/setupJest.ts'
+        ]);
+        assert.noFile([
+          'config/webpack.test.js',
+          'config/karma-test-shim.js',
+          'config/karma.conf.js'
+        ]);
+      });
+    });
+
+    it('should add karma-related code if "testingFramework" is set to "karma" ', () => {
+      let ngLibraryApp = createNgLibraryApp(
+        {
+          skipInstall: true,
+          skipChecks: true
+        },
+        {
+          authorName: 'Awesome Developer',
+          authorEmail: 'awesome.developer@github.com',
+          githubUsername: 'awesomedeveloper',
+          githubRepoName: 'my-ngx-library',
+          projectName: 'my-ngx-library',
+          projectVersion: '1.0.0',
+          projectDescription: 'Angular library for ...',
+          projectkeywords: 'ng, angular,library',
+          ngPrefix: 'my-lib',
+          testingFramework: 'karma',
+          ngVersion: '2.0.0',
+          ngModules: ['core', 'common'],
+          useGreenkeeper: false,
+          useCompodoc: false,
+          enforceNgGitCommitMsg: false
+        });
+      return ngLibraryApp.then(() => {
+        assert.noFileContent('package.json', '    "jest":');
+        assert.file([
+          'config/webpack.test.js',
+          'config/karma-test-shim.js',
+          'config/karma.conf.js'
+        ]);
+        assert.noFile([
+          'config/jestGlobalMocks.ts',
+          'config/setupJest.ts'
+        ]);
       });
     });
   });


### PR DESCRIPTION
First support for `jest` testing platform. Everything works pretty well(integration in generator's prompt, in library and demo app, `gulpfile.js`, etc)

One issue remains though: [lib.component.spec.ts](https://github.com/tinesoft/generator-ngx-library/blob/master/app/templates/src/module/component/_lib.component.spec.ts#L22) failed because of `By.css` i presume. 

Help is wanted!

