### PR TITLE
Fixing lib.component.spec.ts failed on JEST test

### DIFF
--- a/app/templates/src/module/component/_lib.component.spec.ts
+++ b/app/templates/src/module/component/_lib.component.spec.ts
@@ -27,6 +27,6 @@ describe('LibComponent', function () {
   it('should have expected <p> text', () => {
     fixture.detectChanges();
     const p = de.nativeElement;
-    expect(p.innerText).toEqual('<%= projectDescription %>');
+    expect(p.textContent).toEqual('<%= projectDescription %>');
   });
 });


### PR DESCRIPTION
I think there are no more `innerText` field on `nativeElement` object. Replaced with `textContent`.

![image](https://user-images.githubusercontent.com/598188/34764177-98ca9c7a-f628-11e7-8460-72061955b629.png)
