### PR TITLE
Fixed @types/jest error on compiling angular v2 generated project

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -45,7 +45,8 @@
     "webpack-dev-middleware": "1.12.0",
     "webpack-dev-server": "2.9.2",
     "karma-webpack": "2.0.5",<% } else if(testingFramework === 'jest') {%>
-    "@types/jest": "21.1.9",
+    <% if(ngVersionMin == 2) {%>"@types/jest": "16.0.7",<%} 
+    else {%>"@types/jest": "21.1.9",<% } %>
     "jest": "22.0.4",
     "jest-preset-angular": "5.0.0",<% } %>
     "@types/node": "8.0.44",

--- a/app/templates/src/module/component/_lib.component.spec.ts
+++ b/app/templates/src/module/component/_lib.component.spec.ts
@@ -27,6 +27,6 @@ describe('LibComponent', function () {
   it('should have expected <p> text', () => {
     fixture.detectChanges();
     const p = de.nativeElement;
-    expect(p.innerText).toEqual('<%= projectDescription %>');
+    expect(p.textContent).toEqual('<%= projectDescription %>');
   });
 });


### PR DESCRIPTION
Hi @tinesoft, 

Changes on `package.json` template.
Change  @types/jest version based on `ngVersionMin`.