### PR TITLE
chore(package): updated gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -188,7 +188,7 @@ gulp.task('create-new-tag', (cb) => {
 
 gulp.task('build', ['static', 'test'])
 
-gulp.task('npm-publish', gulpShell.task('npm publish'));
+gulp.task('npm-publish', gulpShell.task('npm publish --access public'));
 
 gulp.task('pre-release', cb => {
   readyToRelease();


### PR DESCRIPTION
added public access to the npm-publish script in the gulpfile in order to support scoped packages